### PR TITLE
"Use Currency Code Instead of Symbol" Checkbox Behavior (ADVANTAGE-8494)

### DIFF
--- a/src/NMoneys/Currencies.xml
+++ b/src/NMoneys/Currencies.xml
@@ -2052,4 +2052,16 @@
 		<positivePattern>0</positivePattern>
 		<negativePattern>0</negativePattern>
 	</currency>
+	<currency code="ZZZ">
+		<englishName>Customizable currency</englishName>
+		<nativeName>Customizable currency</nativeName>
+		<symbol></symbol>
+		<significantDecimalDigits>2</significantDecimalDigits>
+		<decimalSeparator>.</decimalSeparator>
+		<groupSeparator>,</groupSeparator>
+		<groupSizes>3</groupSizes>
+		<positivePattern>0</positivePattern>
+		<negativePattern>0</negativePattern>
+		<entity>curren</entity>
+	</currency>
 </currencies>

--- a/src/NMoneys/Currency.cs
+++ b/src/NMoneys/Currency.cs
@@ -163,7 +163,7 @@ namespace NMoneys
 			IsObsolete = isObsolete;
 			Entity = entity;
 
-			FormatInfo = NumberFormatInfo.ReadOnly(new NumberFormatInfo
+			var formatInfo = new NumberFormatInfo
 			{
 				CurrencySymbol = symbol,
 				CurrencyDecimalDigits = significantDecimalDigits,
@@ -177,7 +177,9 @@ namespace NMoneys
 				NumberGroupSeparator = groupSeparator,
 				NumberGroupSizes = groupSizes,
 				NumberNegativePattern = negativePattern.TranslateNegativePattern(),
-			});
+			};
+
+			FormatInfo = isoCode == CurrencyIsoCode.ZZZ ? formatInfo : NumberFormatInfo.ReadOnly(formatInfo);
 		}
 
 		#endregion
@@ -299,6 +301,10 @@ namespace NMoneys
 		/// Testing currency
 		/// </summary>
 		public static readonly Currency Test;
+		/// <summary>
+		/// Currency with customizable format
+		/// </summary>
+		public static readonly Currency Zzz;
 
 		/*private static readonly ThreadSafeCache<string, Currency> _byIsoSymbol;
 		private static readonly ThreadSafeCache<CurrencyIsoCode, Currency> _byIsoCode;*/
@@ -384,6 +390,9 @@ namespace NMoneys
 
 				Xts = init(CurrencyIsoCode.XTS, initializer.Get);
 				_cache.Add(Xts);
+
+				Zzz = init(CurrencyIsoCode.ZZZ, initializer.Get);
+				_cache.Add(Zzz);
 			}
 
 			Euro = Eur;

--- a/src/NMoneys/CurrencyIsoCode.cs
+++ b/src/NMoneys/CurrencyIsoCode.cs
@@ -931,6 +931,11 @@ namespace NMoneys
 		/// Zimbabwe Dollar
 		/// </summary>
 		[EnumMember, CanonicalCulture("en-ZW")]
-		ZWL = 932
+		ZWL = 932,
+		/// <summary>
+		/// Currency with customizable format
+		/// </summary>
+		[EnumMember]
+		ZZZ = 996
 	}
 }


### PR DESCRIPTION
Motivation
----------
Need to make possible currency Code display instead of Symbol with NumberFormatInfo

Modifications
-------------
Made possibility to update Currency FormatInfo properties for "None" currency

Results
-------
Now it is possible to make Currency FormatInfo with currency Code instead of Symbol